### PR TITLE
Platform Defines in cpp

### DIFF
--- a/Common/Public/Common/Platform/ConfigureArchitecture.h
+++ b/Common/Public/Common/Platform/ConfigureArchitecture.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#if defined(COMPILER_CLANG) || defined(COMPILER_GCC)
+#   if defined(__x86_64__) || defined(__i386__)
+#       define PLATFORM_X86 1
+#   elif defined(__arm__) || defined(__aarch64__)
+#       define PLATFORM_ARM 1
+#   elif (__EMSCRIPTEN__)
+#       define PLATFORM_WEB 1
+#   else
+#       error unhandled target architecture
+#   endif
+
+#   if defined(__x86_64__) || defined(__aarch64__)
+#       define PLATFORM_64BIT 1
+#   elif defined(__i386__) || defined(__arm__)
+#       define PLATFORM_32BIT 1
+#   elif (__EMSCRIPTEN__)
+#       define PLATFORM_32BIT 1
+#   else
+#       error unhandled platform bit count
+#   endif
+#elif defined(COMPILER_MSVC)
+#   if defined(_M_AMD64) || defined(_M_IX86)
+#       define PLATFORM_X86 1
+#   elif defined(_M_ARM) || defined(_M_ARM64)
+#       define PLATFORM_ARM 1
+#   else
+#       error unhandled target architecture
+#   endif
+
+#   if defined(_M_AMD64) || defined(_M_ARM64)
+#       define PLATFORM_64BIT 1
+#   elif defined(_M_IX86) || defined(_M_ARM)
+#       define PLATFORM_32BIT 1
+#   else
+#       error unhandled platform bit count
+#   endif
+#endif
+
+
+#ifndef PLATFORM_X86
+#   define PLATFORM_X86 0
+#endif
+
+#ifndef PLATFORM_ARM
+#   define PLATFORM_ARM 0
+#endif
+
+#ifndef PLATFORM_WEB
+#   define PLATFORM_WEB 0
+#endif
+
+#ifndef PLATFORM_64BIT
+#   define PLATFORM_64BIT 0
+#endif
+
+#ifndef PLATFORM_32BIT
+#   define PLATFORM_32BIT 0
+#endif

--- a/Common/Public/Common/Platform/ConfigureCompiler.h
+++ b/Common/Public/Common/Platform/ConfigureCompiler.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#if defined(__clang__)
+#   define COMPILER_CLANG 1
+#   if defined(PLATFORM_WINDOWS)
+#       define COMPILER_CLANG_WINDOWS 1
+#   endif
+#elif defined(__GNUC__)
+#   define COMPILER_GCC 1
+#elif defined(_MSC_VER)
+#   define COMPILER_MSVC 1
+#else
+#   error "Unknown Compiler"
+#endif
+
+#ifndef COMPILER_CLANG
+#   define COMPILER_CLANG 0
+#endif
+
+#ifndef COMPILER_CLANG_WINDOWS
+#   define COMPILER_CLANG_WINDOWS 0
+#endif
+
+#ifndef COMPILER_GCC
+#   define COMPILER_GCC 0
+#endif
+
+#ifndef COMPILER_MSVC
+#   define COMPILER_MSVC 0
+#endif

--- a/Common/Public/Common/Platform/ConfigurePlatform.h
+++ b/Common/Public/Common/Platform/ConfigurePlatform.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#if defined(_WINDOWS) || defined(_WIN32)
+#   define PLATFORM_NAME "Windows"
+#   define PLATFORM_DESKTOP 1
+#   define PLATFORM_WINDOWS 1
+#elif defined(__APPLE__) && defined(__MACH__)
+#   include <TargetConditionals.h>
+#   define PLATFORM_APPLE 1
+#   define PLATFORM_POSIX 1
+#   if TARGET_OS_MAC == 1
+#       define PLATFORM_NAME "MacOS"
+#       define PLATFORM_DESKTOP 1
+#       define PLATFORM_APPLE_MACOS 1
+#   elif TARGET_OS_IOS == 1
+#       if TARGET_OS_MACCATALYST == 1
+#           define PLATFORM_NAME "macCatalyst"
+#           define PLATFORM_DESKTOP 1
+#           define PLATFORM_APPLE_MACCATALYST 1
+#       else
+#           define PLATFORM_NAME "iOS"
+#           define PLATFORM_MOBILE 1
+#           define PLATFORM_APPLE_IOS 1
+#       endif
+#   elif TARGET_OS_VISION == 1
+#       define PLATFORM_NAME "visionOS"
+#       define PLATFORM_SPATIAL 1
+#       define PLATFORM_APPLE_VISIONOS 1
+#   elif TARGET_OS_WATCH == 1
+#       define PLATFORM_NAME "watchOS"
+#       define PLATFORM_WATCH 1
+#       define PLATFORM_APPLE_WATCH 1
+#   endif
+#elif defined (ANDROID)
+#   define PLATFORM_NAME "Android"
+#   define PLATFORM_MOBILE 1
+#   define PLATFORM_ANDROID 1
+#   define PLATFORM_POSIX 1
+#elif defined(__linux)
+#   define PLATFORM_NAME "Linux"
+#   define PLATFORM_DESKTOP 1
+#   define PLATFORM_LINUX 1
+#   define PLATFORM_POSIX 1
+#elif defined(__EMSCRIPTEN__)
+#   define PLATFORM_NAME "Web"
+#   define PLATFORM_WEB 1
+#   define PLATFORM_EMSCRIPTEN 1
+#   define PLATFORM_POSIX 1
+#elif defined(__wasm__) || defined(__wasi__)
+#   define PLATFORM_NAME "Web"
+#   define PLATFORM_WEB 1
+#   define PLATFORM_POSIX 1
+#else
+#   error "PLATFORM UNDEFINED"
+#endif
+
+#ifndef PLATFORM_NAME
+#   define PLATFORM_NAME "UNKNOWN"
+#endif
+
+#ifndef PLATFORM_DESKTOP
+#   define PLATFORM_DESKTOP 0
+#endif
+
+#ifndef PLATFORM_MOBILE
+#   define PLATFORM_MOBILE 0
+#endif
+
+#ifndef PLATFORM_SPATIAL
+#   define PLATFORM_SPATIAL 0
+#endif
+
+#ifndef PLATFORM_WEB
+#   define PLATFORM_WEB 0
+#endif
+
+#ifndef PLATFORM_WINDOWS
+#   define PLATFORM_WINDOWS 0
+#endif
+
+#ifndef PLATFORM_APPLE
+#   define PLATFORM_APPLE 0
+#endif
+
+#ifndef PLATFORM_POSIX
+#   define PLATFORM_POSIX 0
+#endif
+
+#ifndef PLATFORM_APPLE_MACOS
+#   define PLATFORM_APPLE_MACOS 0
+#endif
+
+#ifndef PLATFORM_APPLE_MACOS
+#   define PLATFORM_APPLE_MACOS 0
+#endif
+
+#ifndef PLATFORM_APPLE_MACCATALYST
+#   define PLATFORM_APPLE_MACCATALYST 0
+#endif
+
+#ifndef PLATFORM_APPLE_IOS
+#   define PLATFORM_APPLE_IOS 0
+#endif
+
+#ifndef PLATFORM_APPLE_VISIONOS
+#   define PLATFORM_APPLE_VISIONOS 0
+#endif
+
+#ifndef PLATFORM_APPLE_WATCH
+#   define PLATFORM_APPLE_WATCH 0
+#endif
+
+#ifndef PLATFORM_ANDROID
+#   define PLATFORM_ANDROID 0
+#endif
+
+#ifndef PLATFORM_LINUX
+#   define PLATFORM_LINUX 0
+#endif
+
+#ifndef PLATFORM_EMSCRIPTEN
+#   define PLATFORM_EMSCRIPTEN 0
+#endif


### PR DESCRIPTION
Does what it says. Adds platform defines on the cpp side. 
Doesn't replace the current system as the plan is to make use of a Common/Core header file that includes everything in order. 

